### PR TITLE
add --legacy-peer-deps to npm install

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     },
     "projectOptions": ["normal", "ejected"],
     "nodeVersionRange": ">=4.0.0",
-    "script": "const cp = require('child_process'); const path = require('path'); cp.execSync('git clone https://github.com/reactjs/react-codemod.git .', { cwd }); cp.execSync('npm install --ignore-scripts', { cwd }); cp.spawnSync('node', [path.join(cwd, 'node_modules/jscodeshift/bin/jscodeshift.sh'), '-t', path.join(cwd, 'transforms/create-element-to-jsx.js'), 'src']);"
+    "script": "const cp = require('child_process'); const path = require('path'); cp.execSync('git clone https://github.com/reactjs/react-codemod.git .', { cwd }); cp.execSync('npm install --ignore-scripts --legacy-peer-deps', { cwd }); cp.spawnSync('node', [path.join(cwd, 'node_modules/jscodeshift/bin/jscodeshift.sh'), '-t', path.join(cwd, 'transforms/create-element-to-jsx.js'), 'src']);"
   },
   "error-boundaries": {
     "versionRanges": {
@@ -13,6 +13,6 @@
     },
     "projectOptions": ["normal", "ejected"],
     "nodeVersionRange": ">=4.0.0",
-    "script": "const cp = require('child_process'); const path = require('path'); cp.execSync('git clone https://github.com/reactjs/react-codemod.git .', { cwd }); cp.execSync('npm install --ignore-scripts', { cwd }); cp.spawnSync('node', [path.join(cwd, 'node_modules/jscodeshift/bin/jscodeshift.sh'), '-t', path.join(cwd, 'transforms/error-boundaries.js'), 'src']);"
+    "script": "const cp = require('child_process'); const path = require('path'); cp.execSync('git clone https://github.com/reactjs/react-codemod.git .', { cwd }); cp.execSync('npm install --ignore-scripts --legacy-peer-deps', { cwd }); cp.spawnSync('node', [path.join(cwd, 'node_modules/jscodeshift/bin/jscodeshift.sh'), '-t', path.join(cwd, 'transforms/error-boundaries.js'), 'src']);"
   }
 }


### PR DESCRIPTION
solves

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: react-codemod@5.4.4
npm ERR! Found: eslint@6.8.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^6.6.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^8.56.0" from @typescript-eslint/parser@7.8.0
npm ERR! node_modules/@typescript-eslint/parser
npm ERR!   dev @typescript-eslint/parser@"^7.8.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```